### PR TITLE
support 256 color on windows

### DIFF
--- a/color.go
+++ b/color.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
-	"github.com/shiena/ansicolor"
 )
 
 // NoColor defines if the output is colorized or not. It's dynamically set to
@@ -147,7 +147,7 @@ func (c *Color) prepend(value Attribute) {
 
 // Output defines the standard output of the print functions. By default
 // os.Stdout is used.
-var Output = ansicolor.NewAnsiColorWriter(os.Stdout)
+var Output = colorable.NewColorableStdout()
 
 // Print formats using the default formats for its operands and writes to
 // standard output. Spaces are added between operands when neither is a


### PR DESCRIPTION
I'm thinking this is better for support 256 color. go-colorable round the color code into suitable values in on the windows 16-colors.

This is really 256 color displayed on mintty terminal.

![](http://go-gyazo.appspot.com/7ea4676deb01fa11.png)

Before applying this patch

![](http://go-gyazo.appspot.com/f907bc0093187ca0.png)

After applying this patch

![](http://go-gyazo.appspot.com/8f8a18ac287c07f4.png)
