### PR TITLE
Remove appended newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ go get github.com/fatih/color
 
 ```go
 // Print with default helper functions
-color.Cyan("Prints text in cyan.")
+color.Cyan("Prints text in cyan.\n")
 
-// A newline will be appended automatically
-color.Blue("Prints %s in blue.", "text")
+// a newline will not be automatically added
+color.Blue("Prints %s in blue.\n", "text")
 
 // These are using the default foreground colors
-color.Red("We have red")
-color.Magenta("And many others ..")
+color.Red("We have red ")
+color.Magenta("and many others...\n")
 
 ```
 
@@ -151,4 +151,3 @@ c.Println("This prints again cyan...")
 ## License
 
 The MIT License (MIT) - see [`LICENSE.md`](https://github.com/fatih/color/blob/master/LICENSE.md) for more details
-

--- a/color.go
+++ b/color.go
@@ -312,43 +312,31 @@ func boolPtr(v bool) *bool {
 	return &v
 }
 
-// Black is an convenient helper function to print with black foreground. A
-// newline is appended to format by default.
+// Black is an convenient helper function to print with black foreground.
 func Black(format string, a ...interface{}) { printColor(format, FgBlack, a...) }
 
-// Red is an convenient helper function to print with red foreground. A
-// newline is appended to format by default.
+// Red is an convenient helper function to print with red foreground.
 func Red(format string, a ...interface{}) { printColor(format, FgRed, a...) }
 
-// Green is an convenient helper function to print with green foreground. A
-// newline is appended to format by default.
+// Green is an convenient helper function to print with green foreground.
 func Green(format string, a ...interface{}) { printColor(format, FgGreen, a...) }
 
 // Yellow is an convenient helper function to print with yellow foreground.
-// A newline is appended to format by default.
 func Yellow(format string, a ...interface{}) { printColor(format, FgYellow, a...) }
 
 // Blue is an convenient helper function to print with blue foreground. A
-// newline is appended to format by default.
 func Blue(format string, a ...interface{}) { printColor(format, FgBlue, a...) }
 
 // Magenta is an convenient helper function to print with magenta foreground.
-// A newline is appended to format by default.
 func Magenta(format string, a ...interface{}) { printColor(format, FgMagenta, a...) }
 
 // Cyan is an convenient helper function to print with cyan foreground. A
-// newline is appended to format by default.
 func Cyan(format string, a ...interface{}) { printColor(format, FgCyan, a...) }
 
 // White is an convenient helper function to print with white foreground. A
-// newline is appended to format by default.
 func White(format string, a ...interface{}) { printColor(format, FgWhite, a...) }
 
 func printColor(format string, p Attribute, a ...interface{}) {
-	if !strings.HasSuffix(format, "\n") {
-		format += "\n"
-	}
-
 	c := &Color{params: []Attribute{p}}
 	c.Printf(format, a...)
 }

--- a/doc.go
+++ b/doc.go
@@ -7,8 +7,8 @@ Use simple and default helper functions with predefined foreground colors:
 
     color.Cyan("Prints text in cyan.")
 
-    // a newline will be appended automatically
-    color.Blue("Prints %s in blue.", "text")
+    // a newline will not be appended automatically
+    color.Blue("Prints %s in blue.\n", "text")
 
     // More default foreground colors..
     color.Red("We have red")


### PR DESCRIPTION
For the sake of having a clean api I don't think a newline should automatically be appended to strings to be printed. This would allow for freer use of the library. 

Signed-off-by: Grantseltzer <grantseltzer@gmail.com>