### PR TITLE
Use color cache map

### DIFF
--- a/color.go
+++ b/color.go
@@ -312,6 +312,44 @@ func boolPtr(v bool) *bool {
 	return &v
 }
 
+// colorsCache is used to reduce the count of created Color objects and
+// allows to reuse already created objects with required Attribute.
+var colorsCache = make(map[Attribute]*Color)
+
+func printColor(format string, p Attribute, a ...interface{}) {
+	c, ok := colorsCache[p]
+	if !ok {
+		c = New(p)
+		colorsCache[p] = c
+	}
+
+	if len(a) == 0 {
+		a = append(a, format)
+		format = "%s"
+	}
+
+	if !strings.HasSuffix(format, "\n") {
+		format += "\n"
+	}
+
+	c.Printf(format, a...)
+}
+
+func printString(format string, p Attribute, a ...interface{}) string {
+	c, ok := colorsCache[p]
+	if !ok {
+		c = New(p)
+		colorsCache[p] = c
+	}
+
+	if len(a) == 0 {
+		a = append(a, format)
+		format = "%s"
+	}
+
+	return c.SprintfFunc()(format, a...)
+}
+
 // Black is an convenient helper function to print with black foreground. A
 // newline is appended to format by default.
 func Black(format string, a ...interface{}) { printColor(format, FgBlack, a...) }
@@ -343,28 +381,6 @@ func Cyan(format string, a ...interface{}) { printColor(format, FgCyan, a...) }
 // White is an convenient helper function to print with white foreground. A
 // newline is appended to format by default.
 func White(format string, a ...interface{}) { printColor(format, FgWhite, a...) }
-
-func printColor(format string, p Attribute, a ...interface{}) {
-	if len(a) == 0 {
-		a = append(a, format)
-		format = "%s"
-	}
-
-	if !strings.HasSuffix(format, "\n") {
-		format += "\n"
-	}
-
-	c := &Color{params: []Attribute{p}}
-	c.Printf(format, a...)
-}
-
-func printString(format string, p Attribute, a ...interface{}) string {
-	if len(a) == 0 {
-		a = append(a, format)
-		format = "%s"
-	}
-	return New(p).SprintfFunc()(format, a...)
-}
 
 // BlackString is an convenient helper function to return a string with black
 // foreground.

--- a/color.go
+++ b/color.go
@@ -316,12 +316,17 @@ func boolPtr(v bool) *bool {
 // allows to reuse already created objects with required Attribute.
 var colorsCache = make(map[Attribute]*Color)
 
-func printColor(format string, p Attribute, a ...interface{}) {
+func getCachedColor(p Attribute) *Color {
 	c, ok := colorsCache[p]
 	if !ok {
 		c = New(p)
 		colorsCache[p] = c
 	}
+	return c
+}
+
+func printColor(format string, p Attribute, a ...interface{}) {
+	c := getCachedColor(p)
 
 	if len(a) == 0 {
 		a = append(a, format)
@@ -336,11 +341,7 @@ func printColor(format string, p Attribute, a ...interface{}) {
 }
 
 func printString(format string, p Attribute, a ...interface{}) string {
-	c, ok := colorsCache[p]
-	if !ok {
-		c = New(p)
-		colorsCache[p] = c
-	}
+	c := getCachedColor(p)
 
 	if len(a) == 0 {
 		a = append(a, format)

--- a/color.go
+++ b/color.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
@@ -316,12 +317,18 @@ func boolPtr(v bool) *bool {
 // allows to reuse already created objects with required Attribute.
 var colorsCache = make(map[Attribute]*Color)
 
+var colorsCacheMu = new(sync.Mutex) // protects colorsCache
+
 func getCachedColor(p Attribute) *Color {
+	colorsCacheMu.Lock()
+	defer colorsCacheMu.Unlock()
+
 	c, ok := colorsCache[p]
 	if !ok {
 		c = New(p)
 		colorsCache[p] = c
 	}
+
 	return c
 }
 


### PR DESCRIPTION
printColor and printString create new Color object on every call. If user calls these functions more than one time, Color objects with the same Attribute are created. That consumes memory.
I offer to cache already created objects and reuse them.

And this is strange, what these two functions are between print and string functions, so I place them in a top of these functions.