### PR TITLE
xFunc should return a func w/ identical sig as underlying func

### DIFF
--- a/color.go
+++ b/color.go
@@ -265,50 +265,38 @@ func (c *Color) Sprintf(format string, a ...interface{}) string {
 
 // FprintFunc returns a new function that prints the passed arguments as
 // colorized with color.Fprint().
-func (c *Color) FprintFunc() func(w io.Writer, a ...interface{}) {
-	return func(w io.Writer, a ...interface{}) {
-		c.Fprint(w, a...)
-	}
+func (c *Color) FprintFunc() func(w io.Writer, a ...interface{}) (n int, err error) {
+	return c.Fprint
 }
 
 // PrintFunc returns a new function that prints the passed arguments as
 // colorized with color.Print().
-func (c *Color) PrintFunc() func(a ...interface{}) {
-	return func(a ...interface{}) {
-		c.Print(a...)
-	}
+func (c *Color) PrintFunc() func(a ...interface{}) (n int, err error) {
+	return c.Print
 }
 
 // FprintfFunc returns a new function that prints the passed arguments as
 // colorized with color.Fprintf().
-func (c *Color) FprintfFunc() func(w io.Writer, format string, a ...interface{}) {
-	return func(w io.Writer, format string, a ...interface{}) {
-		c.Fprintf(w, format, a...)
-	}
+func (c *Color) FprintfFunc() func(w io.Writer, format string, a ...interface{}) (n int, err error) {
+	return c.Fprintf
 }
 
 // PrintfFunc returns a new function that prints the passed arguments as
 // colorized with color.Printf().
-func (c *Color) PrintfFunc() func(format string, a ...interface{}) {
-	return func(format string, a ...interface{}) {
-		c.Printf(format, a...)
-	}
+func (c *Color) PrintfFunc() func(format string, a ...interface{}) (n int, err error) {
+	return c.Printf
 }
 
 // FprintlnFunc returns a new function that prints the passed arguments as
 // colorized with color.Fprintln().
-func (c *Color) FprintlnFunc() func(w io.Writer, a ...interface{}) {
-	return func(w io.Writer, a ...interface{}) {
-		c.Fprintln(w, a...)
-	}
+func (c *Color) FprintlnFunc() func(w io.Writer, a ...interface{}) (n int, err error) {
+	return c.Fprintln
 }
 
 // PrintlnFunc returns a new function that prints the passed arguments as
 // colorized with color.Println().
-func (c *Color) PrintlnFunc() func(a ...interface{}) {
-	return func(a ...interface{}) {
-		c.Println(a...)
-	}
+func (c *Color) PrintlnFunc() func(a ...interface{}) (n int, err error) {
+	return c.Println
 }
 
 // SprintFunc returns a new function that returns colorized strings for the


### PR DESCRIPTION
The signature of a func returned by, say, color.PrintFunc should be
the same as fmt.Print. This enables code usage like:

```go
	f := fmt.Print
	if configColor {
		f = color.New(color.FgRed).PrintFunc()
		// f = color.New(color.FgRed).Print // this is sufficient
	}
	f("foo bar")
```

P.S. After this patch, I am not sure why the xFunc family of functions
are still needed (except for backward compatibility). Maybe we should
revise the examples in the documentation to reduce future usage.