### PR TITLE
Add Hi* helpers for hi-intensity colors

### DIFF
--- a/color.go
+++ b/color.go
@@ -524,3 +524,77 @@ func CyanString(format string, a ...interface{}) string { return colorString(for
 // WhiteString is an convenient helper function to return a string with white
 // foreground.
 func WhiteString(format string, a ...interface{}) string { return colorString(format, FgWhite, a...) }
+
+// HiBlack is an convenient helper function to print with hi-intensity black foreground. A
+// newline is appended to format by default.
+func HiBlack(format string, a ...interface{}) { colorPrint(format, FgHiBlack, a...) }
+
+// HiRed is an convenient helper function to print with hi-intensity red foreground. A
+// newline is appended to format by default.
+func HiRed(format string, a ...interface{}) { colorPrint(format, FgHiRed, a...) }
+
+// HiGreen is an convenient helper function to print with hi-intensity green foreground. A
+// newline is appended to format by default.
+func HiGreen(format string, a ...interface{}) { colorPrint(format, FgHiGreen, a...) }
+
+// HiYellow is an convenient helper function to print with hi-intensity yellow foreground.
+// A newline is appended to format by default.
+func HiYellow(format string, a ...interface{}) { colorPrint(format, FgHiYellow, a...) }
+
+// HiBlue is an convenient helper function to print with hi-intensity blue foreground. A
+// newline is appended to format by default.
+func HiBlue(format string, a ...interface{}) { colorPrint(format, FgHiBlue, a...) }
+
+// HiMagenta is an convenient helper function to print with hi-intensity magenta foreground.
+// A newline is appended to format by default.
+func HiMagenta(format string, a ...interface{}) { colorPrint(format, FgHiMagenta, a...) }
+
+// HiCyan is an convenient helper function to print with hi-intensity cyan foreground. A
+// newline is appended to format by default.
+func HiCyan(format string, a ...interface{}) { colorPrint(format, FgHiCyan, a...) }
+
+// HiWhite is an convenient helper function to print with hi-intensity white foreground. A
+// newline is appended to format by default.
+func HiWhite(format string, a ...interface{}) { colorPrint(format, FgHiWhite, a...) }
+
+// HiBlackString is an convenient helper function to return a string with hi-intensity black
+// foreground.
+func HiBlackString(format string, a ...interface{}) string {
+	return colorString(format, FgHiBlack, a...)
+}
+
+// HiRedString is an convenient helper function to return a string with hi-intensity red
+// foreground.
+func HiRedString(format string, a ...interface{}) string { return colorString(format, FgHiRed, a...) }
+
+// HiGreenString is an convenient helper function to return a string with hi-intensity green
+// foreground.
+func HiGreenString(format string, a ...interface{}) string {
+	return colorString(format, FgHiGreen, a...)
+}
+
+// HiYellowString is an convenient helper function to return a string with hi-intensity yellow
+// foreground.
+func HiYellowString(format string, a ...interface{}) string {
+	return colorString(format, FgHiYellow, a...)
+}
+
+// HiBlueString is an convenient helper function to return a string with hi-intensity blue
+// foreground.
+func HiBlueString(format string, a ...interface{}) string { return colorString(format, FgHiBlue, a...) }
+
+// HiMagentaString is an convenient helper function to return a string with hi-intensity magenta
+// foreground.
+func HiMagentaString(format string, a ...interface{}) string {
+	return colorString(format, FgHiMagenta, a...)
+}
+
+// HiCyanString is an convenient helper function to return a string with hi-intensity cyan
+// foreground.
+func HiCyanString(format string, a ...interface{}) string { return colorString(format, FgHiCyan, a...) }
+
+// HiWhiteString is an convenient helper function to return a string with hi-intensity white
+// foreground.
+func HiWhiteString(format string, a ...interface{}) string {
+	return colorString(format, FgHiWhite, a...)
+}

--- a/color.go
+++ b/color.go
@@ -459,141 +459,141 @@ func colorString(format string, p Attribute, a ...interface{}) string {
 	return c.SprintfFunc()(format, a...)
 }
 
-// Black is an convenient helper function to print with black foreground. A
+// Black is a convenient helper function to print with black foreground. A
 // newline is appended to format by default.
 func Black(format string, a ...interface{}) { colorPrint(format, FgBlack, a...) }
 
-// Red is an convenient helper function to print with red foreground. A
+// Red is a convenient helper function to print with red foreground. A
 // newline is appended to format by default.
 func Red(format string, a ...interface{}) { colorPrint(format, FgRed, a...) }
 
-// Green is an convenient helper function to print with green foreground. A
+// Green is a convenient helper function to print with green foreground. A
 // newline is appended to format by default.
 func Green(format string, a ...interface{}) { colorPrint(format, FgGreen, a...) }
 
-// Yellow is an convenient helper function to print with yellow foreground.
+// Yellow is a convenient helper function to print with yellow foreground.
 // A newline is appended to format by default.
 func Yellow(format string, a ...interface{}) { colorPrint(format, FgYellow, a...) }
 
-// Blue is an convenient helper function to print with blue foreground. A
+// Blue is a convenient helper function to print with blue foreground. A
 // newline is appended to format by default.
 func Blue(format string, a ...interface{}) { colorPrint(format, FgBlue, a...) }
 
-// Magenta is an convenient helper function to print with magenta foreground.
+// Magenta is a convenient helper function to print with magenta foreground.
 // A newline is appended to format by default.
 func Magenta(format string, a ...interface{}) { colorPrint(format, FgMagenta, a...) }
 
-// Cyan is an convenient helper function to print with cyan foreground. A
+// Cyan is a convenient helper function to print with cyan foreground. A
 // newline is appended to format by default.
 func Cyan(format string, a ...interface{}) { colorPrint(format, FgCyan, a...) }
 
-// White is an convenient helper function to print with white foreground. A
+// White is a convenient helper function to print with white foreground. A
 // newline is appended to format by default.
 func White(format string, a ...interface{}) { colorPrint(format, FgWhite, a...) }
 
-// BlackString is an convenient helper function to return a string with black
+// BlackString is a convenient helper function to return a string with black
 // foreground.
 func BlackString(format string, a ...interface{}) string { return colorString(format, FgBlack, a...) }
 
-// RedString is an convenient helper function to return a string with red
+// RedString is a convenient helper function to return a string with red
 // foreground.
 func RedString(format string, a ...interface{}) string { return colorString(format, FgRed, a...) }
 
-// GreenString is an convenient helper function to return a string with green
+// GreenString is a convenient helper function to return a string with green
 // foreground.
 func GreenString(format string, a ...interface{}) string { return colorString(format, FgGreen, a...) }
 
-// YellowString is an convenient helper function to return a string with yellow
+// YellowString is a convenient helper function to return a string with yellow
 // foreground.
 func YellowString(format string, a ...interface{}) string { return colorString(format, FgYellow, a...) }
 
-// BlueString is an convenient helper function to return a string with blue
+// BlueString is a convenient helper function to return a string with blue
 // foreground.
 func BlueString(format string, a ...interface{}) string { return colorString(format, FgBlue, a...) }
 
-// MagentaString is an convenient helper function to return a string with magenta
+// MagentaString is a convenient helper function to return a string with magenta
 // foreground.
 func MagentaString(format string, a ...interface{}) string {
 	return colorString(format, FgMagenta, a...)
 }
 
-// CyanString is an convenient helper function to return a string with cyan
+// CyanString is a convenient helper function to return a string with cyan
 // foreground.
 func CyanString(format string, a ...interface{}) string { return colorString(format, FgCyan, a...) }
 
-// WhiteString is an convenient helper function to return a string with white
+// WhiteString is a convenient helper function to return a string with white
 // foreground.
 func WhiteString(format string, a ...interface{}) string { return colorString(format, FgWhite, a...) }
 
-// HiBlack is an convenient helper function to print with hi-intensity black foreground. A
+// HiBlack is a convenient helper function to print with hi-intensity black foreground. A
 // newline is appended to format by default.
 func HiBlack(format string, a ...interface{}) { colorPrint(format, FgHiBlack, a...) }
 
-// HiRed is an convenient helper function to print with hi-intensity red foreground. A
+// HiRed is a convenient helper function to print with hi-intensity red foreground. A
 // newline is appended to format by default.
 func HiRed(format string, a ...interface{}) { colorPrint(format, FgHiRed, a...) }
 
-// HiGreen is an convenient helper function to print with hi-intensity green foreground. A
+// HiGreen is a convenient helper function to print with hi-intensity green foreground. A
 // newline is appended to format by default.
 func HiGreen(format string, a ...interface{}) { colorPrint(format, FgHiGreen, a...) }
 
-// HiYellow is an convenient helper function to print with hi-intensity yellow foreground.
+// HiYellow is a convenient helper function to print with hi-intensity yellow foreground.
 // A newline is appended to format by default.
 func HiYellow(format string, a ...interface{}) { colorPrint(format, FgHiYellow, a...) }
 
-// HiBlue is an convenient helper function to print with hi-intensity blue foreground. A
+// HiBlue is a convenient helper function to print with hi-intensity blue foreground. A
 // newline is appended to format by default.
 func HiBlue(format string, a ...interface{}) { colorPrint(format, FgHiBlue, a...) }
 
-// HiMagenta is an convenient helper function to print with hi-intensity magenta foreground.
+// HiMagenta is a convenient helper function to print with hi-intensity magenta foreground.
 // A newline is appended to format by default.
 func HiMagenta(format string, a ...interface{}) { colorPrint(format, FgHiMagenta, a...) }
 
-// HiCyan is an convenient helper function to print with hi-intensity cyan foreground. A
+// HiCyan is a convenient helper function to print with hi-intensity cyan foreground. A
 // newline is appended to format by default.
 func HiCyan(format string, a ...interface{}) { colorPrint(format, FgHiCyan, a...) }
 
-// HiWhite is an convenient helper function to print with hi-intensity white foreground. A
+// HiWhite is a convenient helper function to print with hi-intensity white foreground. A
 // newline is appended to format by default.
 func HiWhite(format string, a ...interface{}) { colorPrint(format, FgHiWhite, a...) }
 
-// HiBlackString is an convenient helper function to return a string with hi-intensity black
+// HiBlackString is a convenient helper function to return a string with hi-intensity black
 // foreground.
 func HiBlackString(format string, a ...interface{}) string {
 	return colorString(format, FgHiBlack, a...)
 }
 
-// HiRedString is an convenient helper function to return a string with hi-intensity red
+// HiRedString is a convenient helper function to return a string with hi-intensity red
 // foreground.
 func HiRedString(format string, a ...interface{}) string { return colorString(format, FgHiRed, a...) }
 
-// HiGreenString is an convenient helper function to return a string with hi-intensity green
+// HiGreenString is a convenient helper function to return a string with hi-intensity green
 // foreground.
 func HiGreenString(format string, a ...interface{}) string {
 	return colorString(format, FgHiGreen, a...)
 }
 
-// HiYellowString is an convenient helper function to return a string with hi-intensity yellow
+// HiYellowString is a convenient helper function to return a string with hi-intensity yellow
 // foreground.
 func HiYellowString(format string, a ...interface{}) string {
 	return colorString(format, FgHiYellow, a...)
 }
 
-// HiBlueString is an convenient helper function to return a string with hi-intensity blue
+// HiBlueString is a convenient helper function to return a string with hi-intensity blue
 // foreground.
 func HiBlueString(format string, a ...interface{}) string { return colorString(format, FgHiBlue, a...) }
 
-// HiMagentaString is an convenient helper function to return a string with hi-intensity magenta
+// HiMagentaString is a convenient helper function to return a string with hi-intensity magenta
 // foreground.
 func HiMagentaString(format string, a ...interface{}) string {
 	return colorString(format, FgHiMagenta, a...)
 }
 
-// HiCyanString is an convenient helper function to return a string with hi-intensity cyan
+// HiCyanString is a convenient helper function to return a string with hi-intensity cyan
 // foreground.
 func HiCyanString(format string, a ...interface{}) string { return colorString(format, FgHiCyan, a...) }
 
-// HiWhiteString is an convenient helper function to return a string with hi-intensity white
+// HiWhiteString is a convenient helper function to return a string with hi-intensity white
 // foreground.
 func HiWhiteString(format string, a ...interface{}) string {
 	return colorString(format, FgHiWhite, a...)

--- a/color_test.go
+++ b/color_test.go
@@ -199,6 +199,14 @@ func TestColorVisual(t *testing.T) {
 	Magenta("magenta")
 	Cyan("cyan")
 	White("white")
+	HiBlack("hblack")
+	HiRed("hred")
+	HiGreen("hgreen")
+	HiYellow("hyellow")
+	HiBlue("hblue")
+	HiMagenta("hmagenta")
+	HiCyan("hcyan")
+	HiWhite("hwhite")
 
 	// Third visual test
 	fmt.Println()
@@ -266,6 +274,30 @@ func TestNoFormat(t *testing.T) {
 
 	fmt.Printf("%s   %%s = ", WhiteString("White"))
 	White("%s")
+
+	fmt.Printf("%s   %%s = ", HiBlackString("HiBlack"))
+	HiBlack("%s")
+
+	fmt.Printf("%s     %%s = ", HiRedString("HiRed"))
+	HiRed("%s")
+
+	fmt.Printf("%s   %%s = ", HiGreenString("HiGreen"))
+	HiGreen("%s")
+
+	fmt.Printf("%s  %%s = ", HiYellowString("HiYellow"))
+	HiYellow("%s")
+
+	fmt.Printf("%s    %%s = ", HiBlueString("HiBlue"))
+	HiBlue("%s")
+
+	fmt.Printf("%s %%s = ", HiMagentaString("HiMagenta"))
+	HiMagenta("%s")
+
+	fmt.Printf("%s    %%s = ", HiCyanString("HiCyan"))
+	HiCyan("%s")
+
+	fmt.Printf("%s   %%s = ", HiWhiteString("HiWhite"))
+	HiWhite("%s")
 }
 
 func TestNoFormatString(t *testing.T) {

--- a/color_test.go
+++ b/color_test.go
@@ -248,6 +248,14 @@ func TestColorVisual(t *testing.T) {
 	fmt.Fprintln(Output, MagentaString("magenta"))
 	fmt.Fprintln(Output, CyanString("cyan"))
 	fmt.Fprintln(Output, WhiteString("white"))
+	fmt.Fprintln(Output, HiBlackString("hblack"))
+	fmt.Fprintln(Output, HiRedString("hred"))
+	fmt.Fprintln(Output, HiGreenString("hgreen"))
+	fmt.Fprintln(Output, HiYellowString("hyellow"))
+	fmt.Fprintln(Output, HiBlueString("hblue"))
+	fmt.Fprintln(Output, HiMagentaString("hmagenta"))
+	fmt.Fprintln(Output, HiCyanString("hcyan"))
+	fmt.Fprintln(Output, HiWhiteString("hwhite"))
 }
 
 func TestNoFormat(t *testing.T) {
@@ -315,6 +323,14 @@ func TestNoFormatString(t *testing.T) {
 		{MagentaString, "%s", nil, "\x1b[35m%s\x1b[0m"},
 		{CyanString, "%s", nil, "\x1b[36m%s\x1b[0m"},
 		{WhiteString, "%s", nil, "\x1b[37m%s\x1b[0m"},
+		{HiBlackString, "%s", nil, "\x1b[90m%s\x1b[0m"},
+		{HiRedString, "%s", nil, "\x1b[91m%s\x1b[0m"},
+		{HiGreenString, "%s", nil, "\x1b[92m%s\x1b[0m"},
+		{HiYellowString, "%s", nil, "\x1b[93m%s\x1b[0m"},
+		{HiBlueString, "%s", nil, "\x1b[94m%s\x1b[0m"},
+		{HiMagentaString, "%s", nil, "\x1b[95m%s\x1b[0m"},
+		{HiCyanString, "%s", nil, "\x1b[96m%s\x1b[0m"},
+		{HiWhiteString, "%s", nil, "\x1b[97m%s\x1b[0m"},
 	}
 
 	for i, test := range tests {

--- a/doc.go
+++ b/doc.go
@@ -15,6 +15,11 @@ Use simple and default helper functions with predefined foreground colors:
     color.Yellow("Yellow color too!")
     color.Magenta("And many others ..")
 
+    // Hi-intensity colors
+    color.HiGreen("Bright green color.")
+    color.HiBlack("Bright black means gray..")
+    color.HiWhite("Shiny white color!")
+
 However there are times where custom color mixes are required. Below are some
 examples to create custom color objects and use the print functions of each
 separate color object.
@@ -74,7 +79,7 @@ Or create SprintXxx functions to mix strings with other non-colorized strings:
     info := New(FgWhite, BgGreen).SprintFunc()
     fmt.Printf("this %s rocks!\n", info("package"))
 
-Windows support is enabled by default. All Print functions works as intended.
+Windows support is enabled by default. All Print functions work as intended.
 However only for color.SprintXXX functions, user should use fmt.FprintXXX and
 set the output to color.Output:
 


### PR DESCRIPTION
Hi,

I added `Hi*()` helpers (like `HiRed()`) for hi-intensity colors as well as normal colors.

I added them because only 8 of 16 colors have helpers. I feel hi-intensity colors are as popular as normal colors and used in many places. At least, I wanted to use hi-black for making a text not stand out, and hi-white for making a text be noticeable. 