### PR TITLE
Fprint and FprintFunc should have same signature

### DIFF
--- a/color.go
+++ b/color.go
@@ -265,9 +265,9 @@ func (c *Color) Sprintf(format string, a ...interface{}) string {
 
 // FprintFunc returns a new function that prints the passed arguments as
 // colorized with color.Fprint().
-func (c *Color) FprintFunc() func(w io.Writer, a ...interface{}) {
-	return func(w io.Writer, a ...interface{}) {
-		c.Fprint(w, a...)
+func (c *Color) FprintFunc() func(w io.Writer, a ...interface{}) (n int, err error) {
+	return func(w io.Writer, a ...interface{}) (n int, err error) {
+		return c.Fprint(w, a...)
 	}
 }
 


### PR DESCRIPTION
In order to create a ColoredWriter which implements the io.Writer interface it is useful to have FprintFunc return `(int, error)` just like `Fprint` itself.