### PR TITLE
use https:// links to avoid broken images in mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Color [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/fatih/color) [![Build Status](http://img.shields.io/travis/fatih/color.svg?style=flat-square)](https://travis-ci.org/fatih/color)
+# Color [![GoDoc](https://godoc.org/github.com/fatih/color?status.svg)](https://godoc.org/github.com/fatih/color) [![Build Status](https://img.shields.io/travis/fatih/color.svg?style=flat-square)](https://travis-ci.org/fatih/color)
 
 
 
@@ -8,7 +8,7 @@ has support for Windows too! The API can be used in several ways, pick one that
 suits you.
 
 
-![Color](http://i.imgur.com/c1JI0lA.png)
+![Color](https://i.imgur.com/c1JI0lA.png)
 
 
 ## Install


### PR DESCRIPTION
Godoc markdown copied from https://godoc.org/github.com/fatih/color?tools

Avoiding http:// images would fix broken images in GHE mirrors - 
![screen shot 2017-08-04 at 11 12 40 am](https://user-images.githubusercontent.com/31205/28962453-07a4067c-7906-11e7-8a7d-b9c3b5981d08.png)
