### PR TITLE
Expose colorable Stderr to use as writer

### DIFF
--- a/color.go
+++ b/color.go
@@ -24,6 +24,9 @@ var (
 	// os.Stdout is used.
 	Output = colorable.NewColorableStdout()
 
+	// Error defines a color supporting writer for os.Stderr.
+	Error = colorable.NewColorableStderr()
+
 	// colorsCache is used to reduce the count of created Color objects and
 	// allows to reuse already created objects with required Attribute.
 	colorsCache   = make(map[Attribute]*Color)


### PR DESCRIPTION
Since printing colors on Windows requires defining the colorised writer (`fmt.Fprint(color.Output, ...)`), this PR exposes the equivalent colorised Stderr writer. So the following would be supported:

```go
var green = color.New(color.FgGreen).SprintFunc()
var red = color.New(color.FgRed).SprintFunc()

fmt.Fprintln(color.Output, green("This is normal green text")) // Prints to os.Stdout
fmt.Fprintln(color.Output, red("This is normal red text")) // Prints to os.Stdout
fmt.Fprintln(color.Error, red("This is error red text"))  // Prints to os.Stderr
```