### PR TITLE
Allow force enable colored output with an environment variable

### DIFF
--- a/color.go
+++ b/color.go
@@ -17,8 +17,9 @@ var (
 	// false or true based on the stdout's file descriptor referring to a terminal
 	// or not. This is a global option and affects all colors. For more control
 	// over each color block use the methods DisableColor() individually.
-	NoColor = os.Getenv("TERM") == "dumb" ||
-		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))
+	NoColor = os.Getenv("FORCE_ENABLE_COLOR") != "1" &&
+		(os.Getenv("TERM") == "dumb" ||
+			(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())))
 
 	// Output defines the standard output of the print functions. By default
 	// os.Stdout is used.


### PR DESCRIPTION
Use case: when you have tool that calls another tool that uses fatih/color, redirecting output (e.g. using os/exec), you lose colors, because it don't pass the checks provided by mattn/go-isatty

An environment variable would allow you to bypass that check