### PR TITLE
Fix newline in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ definitions. For example suppose you have a CLI app and a `--no-color` bool flag
 can easily disable the color output with:
 
 ```go
-
 var flagNoColor = flag.Bool("no-color", false, "Disable color output")
 
 if *flagNoColor {


### PR DESCRIPTION
pkg.go.dev was showing an unnecessary newline in one of the code blocks.