### PR TITLE
Add color.Merge(colors ...*Color)

### DIFF
--- a/color.go
+++ b/color.go
@@ -113,6 +113,20 @@ func New(value ...Attribute) *Color {
 	return c
 }
 
+// Merge adds all SGR parameters from the given colors and returns a new color.
+// Example:
+//     a := color.New(color.FgRed)
+//     b := color.New(color.Bold, color.BgGreen)
+//     c := color.New(color.Italic)
+//     m := color.Merge(a, b, c /* ... */)        // returns a new color without modifying a, b, or c
+func Merge(colors ...*Color) *Color {
+	merged := New()
+	for _, c := range colors {
+		merged.params = append(merged.params, c.params...)
+	}
+	return merged
+}
+
 // Set sets the given parameters immediately. It will change the color of
 // output with the given SGR parameters until color.Unset() is called.
 func Set(p ...Attribute) *Color {

--- a/color_test.go
+++ b/color_test.go
@@ -235,7 +235,20 @@ func TestColorVisual(t *testing.T) {
 	fmt.Fprintf(Output, "this %s rocks!\n", info("package"))
 
 	notice := New(FgBlue).FprintFunc()
-	notice(os.Stderr, "just a blue notice to stderr")
+	notice(os.Stderr, "just a blue notice to stderr\n")
+
+	// Test Merge
+	a := New(FgRed)
+	b := New(Bold, Italic)
+	m := Merge(a, b)
+	expectedColor := New(FgRed, Bold, Italic)
+
+	fmt.Println(m.Sprintf("this is the merged color"))
+	fmt.Println(expectedColor.Sprintf("this is the expected color"))
+
+	if !m.Equals(expectedColor) {
+		t.Error("Merged color is not equal to expected color")
+	}
 
 	// Fifth Visual Test
 	fmt.Println()


### PR DESCRIPTION
Adds `Merge(colors ...*Color)` for merging colors together:

```go
a := color.New(color.FgRed)
b := color.New(color.Bold, color.BgGreen)
c := color.New(color.Italic)
m := color.Merge(a, b, c /* ... */)        // returns a new color without modifying a, b, or c
```

Fixes #128
