### PR TITLE
typo/ add 'color' in front FgBlue to be declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ notice("Don't forget this...")
 ### Custom fprint functions (FprintFunc)
 
 ```go
-blue := color.New(FgBlue).FprintfFunc()
+blue := color.New(color.FgBlue).FprintfFunc()
 blue(myWriter, "important notice: %s", stars)
 
 // Mix up with multiple attributes


### PR DESCRIPTION
Add `color.` in front of FgBlue to avoid undeclared name in exemple