### PR TITLE
Update README to reflect 1.18 go get deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ suits you.
 ## Install
 
 ```bash
-go get github.com/fatih/color
+go install github.com/fatih/color
 ```
 
 ## Examples


### PR DESCRIPTION
Updated README from `go get` to `go install` to reflect 1.18 deprecation of go get. 