### PR TITLE
Make enable/disable color chainable

### DIFF
--- a/color.go
+++ b/color.go
@@ -385,14 +385,16 @@ func (c *Color) unformat() string {
 // DisableColor disables the color output. Useful to not change any existing
 // code and still being able to output. Can be used for flags like
 // "--no-color". To enable back use EnableColor() method.
-func (c *Color) DisableColor() {
+func (c *Color) DisableColor() *Color {
 	c.noColor = boolPtr(true)
+	return c
 }
 
 // EnableColor enables the color output. Use it in conjunction with
 // DisableColor(). Otherwise this method has no side effects.
-func (c *Color) EnableColor() {
+func (c *Color) EnableColor() *Color {
 	c.noColor = boolPtr(false)
+	return c
 }
 
 func (c *Color) isNoColorSet() bool {

--- a/color_test.go
+++ b/color_test.go
@@ -130,9 +130,7 @@ func TestNoColor(t *testing.T) {
 	}
 
 	for _, c := range testColors {
-		p := New(c.code)
-		p.DisableColor()
-		p.Print(c.text)
+		New(c.code).DisableColor().Print(c.text)
 
 		line, _ := rb.ReadString('\n')
 		if line != c.text {
@@ -197,7 +195,6 @@ func TestNoColor_Env(t *testing.T) {
 			t.Errorf("Expecting %s, got '%s'\n", c.text, line)
 		}
 	}
-
 }
 
 func TestColorVisual(t *testing.T) {


### PR DESCRIPTION
It's helpful in reducing unnecessary code, and it does not cause break change.

before
```go
c := color.New(color.FgCyan)
c.EnableColor()
colorStr := c.Sprintf("foo")
```

after
```go
colorStr := color.New(color.FgCyan).EnableColor().Sprintf("foo")
```