### PR TITLE
NO_COLOR requires a non-empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ suits you.
 
 ![Color](https://user-images.githubusercontent.com/438920/96832689-03b3e000-13f4-11eb-9803-46f4c4de3406.jpg)
 
-
 ## Install
 
 ```bash
@@ -124,17 +123,17 @@ fmt.Println("All text will now be bold magenta.")
 ```
 
 ### Disable/Enable color
- 
+
 There might be a case where you want to explicitly disable/enable color output. the 
 `go-isatty` package will automatically disable color output for non-tty output streams 
 (for example if the output were piped directly to `less`).
 
 The `color` package also disables color output if the [`NO_COLOR`](https://no-color.org) environment
-variable is set (regardless of its value).
+variable is set to a non-empty string.
 
 `Color` has support to disable/enable colors programatically both globally and
 for single color definitions. For example suppose you have a CLI app and a
-`--no-color` bool flag. You can easily disable the color output with:
+`-no-color` bool flag. You can easily disable the color output with:
 
 ```go
 var flagNoColor = flag.Bool("no-color", false, "Disable color output")
@@ -167,11 +166,10 @@ To output color in GitHub Actions (or other CI systems that support ANSI colors)
 * Save/Return previous values
 * Evaluate fmt.Formatter interface
 
-
 ## Credits
 
- * [Fatih Arslan](https://github.com/fatih)
- * Windows support via @mattn: [colorable](https://github.com/mattn/go-colorable)
+* [Fatih Arslan](https://github.com/fatih)
+* Windows support via @mattn: [colorable](https://github.com/mattn/go-colorable)
 
 ## License
 

--- a/color.go
+++ b/color.go
@@ -19,7 +19,7 @@ var (
 	// set (regardless of its value). This is a global option and affects all
 	// colors. For more control over each color block use the methods
 	// DisableColor() individually.
-	NoColor = noColorExists() || os.Getenv("TERM") == "dumb" ||
+	NoColor = noColorIsSet() || os.Getenv("TERM") == "dumb" ||
 		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))
 
 	// Output defines the standard output of the print functions. By default
@@ -35,10 +35,9 @@ var (
 	colorsCacheMu sync.Mutex // protects colorsCache
 )
 
-// noColorExists returns true if the environment variable NO_COLOR exists.
-func noColorExists() bool {
-	_, exists := os.LookupEnv("NO_COLOR")
-	return exists
+// noColorIsSet returns true if the environment variable NO_COLOR is set to a non-empty string.
+func noColorIsSet() bool {
+	return os.Getenv("NO_COLOR") != ""
 }
 
 // Color defines a custom color object which is defined by SGR parameters.
@@ -120,7 +119,7 @@ func New(value ...Attribute) *Color {
 		params: make([]Attribute, 0),
 	}
 
-	if noColorExists() {
+	if noColorIsSet() {
 		c.noColor = boolPtr(true)
 	}
 

--- a/color_test.go
+++ b/color_test.go
@@ -183,7 +183,7 @@ func TestNoColor_Env(t *testing.T) {
 		{text: "hwhite", code: FgHiWhite},
 	}
 
-	os.Setenv("NO_COLOR", "")
+	os.Setenv("NO_COLOR", "1")
 	t.Cleanup(func() {
 		os.Unsetenv("NO_COLOR")
 	})
@@ -197,7 +197,6 @@ func TestNoColor_Env(t *testing.T) {
 			t.Errorf("Expecting %s, got '%s'\n", c.text, line)
 		}
 	}
-
 }
 
 func TestColorVisual(t *testing.T) {


### PR DESCRIPTION
## Why

The https://no-color.org/ requires handling empty value in way as if the value was not set.

> should check for a `NO_COLOR` environment variable that, when present and not an empty string (regardless of its value), prevents the addition of ANSI color

I find it a lot better for several reasons.

The problem is that not all languages/OSes/shells are handling an empty value in the same way.

In .NET (C# etc) setting an empty value unsets the environmental variable (sic!). See: https://docs.microsoft.com/en-us/dotnet/api/system.environment.setenvironmentvariable?view=net-5.0

On Windows setting an empty env var is VERY tricky. I suspect 95% of Windows IT users may have real problems doing it. You cannot do it in the command prompt. not via PowerShell, not via GUI. It is possible via Windows Registry or WinAPI, but it is VERY inconvenient and hacky.

Also from a pure usability point of view, `echo $SOMEVAR` does not allow to distinguish between empty and unset.

Having a different interpretation of an empty and unset environment variable can be seen as a kind of "billion-dollar mistake" 😉

Reference: https://unix.stackexchange.com/questions/27708/is-there-a-difference-between-setting-an-environment-variable-to-the-empty-strin

At last, many software see empty env vars as though as it they are not set e.g. https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#parsing-empty-value

## What

1. Change the `NO_COLOR` so that the empty string is handled in the same way as it would be unset
2. Some opportunistic fixes 