### PR TITLE
windows: enable virtual terminal processing, fixes #169

### DIFF
--- a/color_windows.go
+++ b/color_windows.go
@@ -1,0 +1,17 @@
+package color
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func init() {
+	// Opt-in for ansi color support for current process.
+	// https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#output-sequences
+	var outMode uint32
+	out := windows.Handle(os.Stdout.Fd())
+	if err := windows.GetConsoleMode(out, &outMode); err == nil {
+		_ = windows.SetConsoleMode(out, outMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.16
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab
 )


### PR DESCRIPTION
This patch fixes color display in Windows, when not running in a shell that takes care of this automatically.

If you run your go app thru Windows Powershell or Windows Terminal, they both take care of this automatically and you would not need this patch.

However, if you chose to use other shells such as bash, then without this patch you will only see ansi codes. More info in https://github.com/fatih/color/issues/169#issuecomment-1335995045