### PR TITLE
windows: enable virtual terminal processing, fixes #169

### DIFF
--- a/color_windows.go
+++ b/color_windows.go
@@ -1,0 +1,18 @@
+package color
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func init() {
+	// Opt-in for ansi color support for current process.
+	// https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#output-sequences
+	var outMode uint32
+	out := windows.Handle(os.Stdout.Fd())
+	if err := windows.GetConsoleMode(out, &outMode); err == nil {
+		outMode |= windows.ENABLE_PROCESSED_OUTPUT | windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
+		_ = windows.SetConsoleMode(out, outMode)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/mattn/go-isatty v0.0.17
 )
 
-require golang.org/x/sys v0.3.0 // indirect
+require golang.org/x/sys v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,5 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
-golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This PR supersedes #173 because I accidentally deleted local fork.

It is the same PR except x/sys bumped to 0.5.0.