### PR TITLE
Address feedback from pellared

### DIFF
--- a/color_windows.go
+++ b/color_windows.go
@@ -11,8 +11,10 @@ func init() {
 	// https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#output-sequences
 	var outMode uint32
 	out := windows.Handle(os.Stdout.Fd())
-	if err := windows.GetConsoleMode(out, &outMode); err == nil {
-		outMode |= windows.ENABLE_PROCESSED_OUTPUT | windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
-		_ = windows.SetConsoleMode(out, outMode)
+	if err := windows.GetConsoleMode(out, &outMode); err != nil || NoColor {
+		return
 	}
+
+	outMode |= windows.ENABLE_PROCESSED_OUTPUT | windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
+	_ = windows.SetConsoleMode(out, outMode)
 }


### PR DESCRIPTION
- NO_COLOR env is respected in color_windows.go
- fixes indent