### PR TITLE
color: add newline after wrapping text

### DIFF
--- a/color.go
+++ b/color.go
@@ -246,10 +246,7 @@ func (c *Color) Printf(format string, a ...interface{}) (n int, err error) {
 // On Windows, users should wrap w with colorable.NewColorable() if w is of
 // type *os.File.
 func (c *Color) Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
-	c.SetWriter(w)
-	defer c.UnsetWriter(w)
-
-	return fmt.Fprintln(w, a...)
+	return fmt.Fprintln(w, c.wrap(fmt.Sprint(a...)))
 }
 
 // Println formats using the default formats for its operands and writes to
@@ -258,10 +255,7 @@ func (c *Color) Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
 // encountered. This is the standard fmt.Print() method wrapped with the given
 // color.
 func (c *Color) Println(a ...interface{}) (n int, err error) {
-	c.Set()
-	defer c.unset()
-
-	return fmt.Fprintln(Output, a...)
+	return fmt.Fprintln(Output, c.wrap(fmt.Sprint(a...)))
 }
 
 // Sprint is just like Print, but returns a string instead of printing it.
@@ -271,7 +265,7 @@ func (c *Color) Sprint(a ...interface{}) string {
 
 // Sprintln is just like Println, but returns a string instead of printing it.
 func (c *Color) Sprintln(a ...interface{}) string {
-	return c.wrap(fmt.Sprintln(a...))
+	return fmt.Sprintln(c.Sprint(a...))
 }
 
 // Sprintf is just like Printf, but returns a string instead of printing it.
@@ -353,7 +347,7 @@ func (c *Color) SprintfFunc() func(format string, a ...interface{}) string {
 // string. Windows users should use this in conjunction with color.Output.
 func (c *Color) SprintlnFunc() func(a ...interface{}) string {
 	return func(a ...interface{}) string {
-		return c.wrap(fmt.Sprintln(a...))
+		return fmt.Sprintln(c.Sprint(a...))
 	}
 }
 

--- a/color_test.go
+++ b/color_test.go
@@ -3,6 +3,7 @@ package color
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 
@@ -417,4 +418,54 @@ func TestNoFormatString(t *testing.T) {
 			t.Errorf("[%d] want: %q, got: %q", i, test.want, s)
 		}
 	}
+}
+
+func TestColor_Println_Newline(t *testing.T) {
+	rb := new(bytes.Buffer)
+	Output = rb
+
+	c := New(FgRed)
+	c.Println("foo")
+
+	got := readRaw(t, rb)
+	want := "\x1b[31mfoo\x1b[0m\n"
+
+	if want != got {
+		t.Errorf("Println newline error\n\nwant: %q\n got: %q", want, got)
+	}
+}
+
+func TestColor_Sprintln_Newline(t *testing.T) {
+	c := New(FgRed)
+
+	got := c.Sprintln("foo")
+	want := "\x1b[31mfoo\x1b[0m\n"
+
+	if want != got {
+		t.Errorf("Println newline error\n\nwant: %q\n got: %q", want, got)
+	}
+}
+
+func TestColor_Fprintln_Newline(t *testing.T) {
+	rb := new(bytes.Buffer)
+	c := New(FgRed)
+	c.Fprintln(rb, "foo")
+
+	got := readRaw(t, rb)
+	want := "\x1b[31mfoo\x1b[0m\n"
+
+	if want != got {
+		t.Errorf("Println newline error\n\nwant: %q\n got: %q", want, got)
+	}
+}
+
+func readRaw(t *testing.T, r io.Reader) string {
+	t.Helper()
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(out)
 }


### PR DESCRIPTION
The newline should be added after wrapping the input with escape sequences. That way `less` or other commands can parse the output correctly.

before:
<img width="300" alt="ss-2023-03-12-160043" src="https://user-images.githubusercontent.com/438920/224546320-b31a8618-baf3-47e0-a549-416503998704.png">


after:

<img width="295" alt="ss-2023-03-12-160230" src="https://user-images.githubusercontent.com/438920/224546403-2a5741a3-7ef4-4046-bd6a-77a4bafdff5f.png">


fixes https://github.com/fatih/color/issues/157
