### PR TITLE
Bump GitHub workflow actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go 
       uses: actions/setup-go@v5
       with:
         go-version: '>=1.22.0'
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Run go mod tidy
       run: |
@@ -39,9 +39,9 @@ jobs:
       run: "go vet ./..."
 
     - name: Staticcheck
-      uses: dominikh/staticcheck-action@v1.3.0
+      uses: dominikh/staticcheck-action@v1.3.1
       with:
-        version: "2023.1.7"
+        version: "2024.1.1"
         install-go: false
 
     - name: Build

--- a/color.go
+++ b/color.go
@@ -401,7 +401,7 @@ func (c *Color) format() string {
 
 func (c *Color) unformat() string {
 	//return fmt.Sprintf("%s[%dm", escape, Reset)
-	//for each element in sequence let's use the speficic reset escape, ou the generic one if not found
+	//for each element in sequence let's use the specific reset escape, or the generic one if not found
 	format := make([]string, len(c.params))
 	for i, v := range c.params {
 		format[i] = strconv.Itoa(int(Reset))


### PR DESCRIPTION
GitHub emits warnings for GitHub workflow actions, as e.g. seen [here](https://github.com/fatih/color/actions/runs/9376751754).

```
Restore cache failed: Dependencies file is not found in /home/runner/work/color/color.
Supported file pattern: go.sum
```

This PR fixes that issue, thus closing #226, too.
It also fixes a typo in the way.