### PR TITLE
Add Hyperlink support + minor consistency improvements

### DIFF
--- a/color.go
+++ b/color.go
@@ -208,12 +208,13 @@ func (c *Color) Set() *Color {
 	return c
 }
 
-func (c *Color) unset() {
+func (c *Color) Unset() *Color {
 	if c.isNoColorSet() {
-		return
+		return c
 	}
 
-	Unset()
+	fmt.Fprint(Output, c.unformat())
+	return c
 }
 
 // SetWriter is used to set the SGR sequence with the given io.Writer. This is
@@ -235,7 +236,7 @@ func (c *Color) UnsetWriter(w io.Writer) {
 		return
 	}
 
-	fmt.Fprintf(w, "%s[%dm", escape, Reset)
+	fmt.Fprint(w, c.unformat())
 }
 
 // Add is used to chain SGR parameters. Use as many as parameters to combine
@@ -264,7 +265,7 @@ func (c *Color) Fprint(w io.Writer, a ...interface{}) (n int, err error) {
 // color.
 func (c *Color) Print(a ...interface{}) (n int, err error) {
 	c.Set()
-	defer c.unset()
+	defer c.Unset()
 
 	return fmt.Fprint(Output, a...)
 }
@@ -285,7 +286,7 @@ func (c *Color) Fprintf(w io.Writer, format string, a ...interface{}) (n int, er
 // This is the standard fmt.Printf() method wrapped with the given color.
 func (c *Color) Printf(format string, a ...interface{}) (n int, err error) {
 	c.Set()
-	defer c.unset()
+	defer c.Unset()
 
 	return fmt.Fprintf(Output, format, a...)
 }

--- a/color_test.go
+++ b/color_test.go
@@ -238,6 +238,7 @@ func Test_noColorIsSet(t *testing.T) {
 func TestColorVisual(t *testing.T) {
 	// First Visual Test
 	Output = colorable.NewColorableStdout()
+	NoColor = false
 
 	New(FgRed).Printf("red\t")
 	New(BgRed).Print("         ")
@@ -266,6 +267,8 @@ func TestColorVisual(t *testing.T) {
 	New(FgWhite).Printf("white\t")
 	New(BgWhite).Print("         ")
 	New(FgWhite, Bold).Println(" white")
+	New(FgGreen).Hyperlink("https://example.com").Println("This should be clickable if your terminal supports it!")
+
 	fmt.Println("")
 
 	// Second Visual test
@@ -638,4 +641,38 @@ func TestSpecificUnset(t *testing.T) {
 			t.Errorf("UnsetWriter specific reset failed:\n want: %q\n  got: %q", want, got)
 		}
 	})
+}
+
+func TestHyperlink_WithColor(t *testing.T) {
+	link := "https://example.com"
+	text := "click me"
+	c := New(FgBlue).Hyperlink(link)
+	got := c.Sprint(text)
+	want := "\x1b]8;;" + link + "\x1b\\" + "\x1b[34m" + text + "\x1b[0m" + "\x1b]8;;\x1b\\"
+	if got != want {
+		t.Errorf("Expected %q, got %q", want, got)
+	}
+}
+
+func TestHyperlink_NoColor(t *testing.T) {
+	link := "https://example.com"
+	text := "click me"
+	c := New(FgBlue).Hyperlink(link)
+	c.DisableColor()
+	got := c.Sprint(text)
+	if got != text {
+		t.Errorf("Expected plain text %q when color is disabled, got %q", text, got)
+	}
+}
+
+func TestHyperlink_Fprint(t *testing.T) {
+	link := "https://example.com"
+	text := "test output"
+	var buf bytes.Buffer
+	c := New(FgGreen).Hyperlink(link)
+	c.Fprint(&buf, text)
+	want := "\x1b]8;;" + link + "\x1b\\" + "\x1b[32m" + text + "\x1b[0m" + "\x1b]8;;\x1b\\"
+	if buf.String() != want {
+		t.Errorf("Expected %q, got %q", want, buf.String())
+	}
 }


### PR DESCRIPTION
Fixes #253 .

Copy paste of 'hyperlink support' commit:

> [1] lays out a standard for terminals to support hyperlinked text.
> Support is quite widespread but not universal. Examples of support
> include iTerm2, Ghostty, Alacritty, Hyper, Kitty, and more [2].
> 
> This OSC 8 standard is achieved via escape codes, very similar to what
> this project does with colors and other attributes - it's a natural fit.
> 
> Because it is a little unique in how it functions, this 'hyperlink'
> feature doesn't follow the existing 'Attribute' pattern. Instead, it's a
> standalone field which gets special handling. That said, updating just
> c.format and c.unformat is enough, as with the last commit, these are
> now used in all relevant spots that affect formatting.
> 
> [1] https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
> [2] https://github.com/Alhadis/OSC8-Adoption/?tab=readme-ov-file

I also include a preceding commit to make our use of `c.format` and `c.unformat` more consistent, as I noticed my `Hyperlink_Fprint` test was failing due to what appeared like a bug. Namely, in my test, I use `c.Fprint` which uses `c.SetWriter` and `c.UnsetWriter`. `c.UnsetWriter` was not invoking `c.unformat` but was instead applying its own global reset, which seems like an oversight. By re-using `c.unformat`, things work more consistently.

---

Please take a look, keen to hear feedback :) Thanks for your work on the library!
